### PR TITLE
[Bug] [+Fix en validations] Pastilles non différenciées des notes

### DIFF
--- a/Chrome/V5.0.2/start.js
+++ b/Chrome/V5.0.2/start.js
@@ -169,6 +169,9 @@ function averageCalculator() {
               tableConfiguration["notes"]
             ].querySelectorAll("button > span")) {
               // Récuperation de la note
+              if (notes.classList[0] != "valeur") {
+                  continue;
+              }
               var note = parseFloat(
                 notes.childNodes[0].nodeValue.replace(",", ".")
               );

--- a/Firefox/V5.0.0/start.js
+++ b/Firefox/V5.0.0/start.js
@@ -138,11 +138,14 @@ function averageCalculator() {
       for (line of document.getElementsByClassName("table releve")[0].rows) {
         if (
           line.classList[0] == "ng-star-inserted" &&
-          line.cells.item(3).childNodes.length > 1
+          line.cells.item(1).childNodes.length > 1
         ) {
           lineNotesCoefsSum = 0;
           lineCoefs = 0;
-          for (notes of line.cells.item(3).querySelectorAll("button>span")) {
+          for (notes of line.cells.item(1).querySelectorAll("button>span")) {
+            if (notes.classList[0] != "valeur") {
+                continue;
+            }
             var note = parseFloat(
               notes.childNodes[0].nodeValue.replace(",", ".")
             );
@@ -171,7 +174,7 @@ function averageCalculator() {
             }
           }
           lineAverage = lineNotesCoefsSum / lineCoefs;
-          line.cells.item(2).querySelector("span").innerText = hundredthRound(
+          line.cells.item(1).querySelector("span").innerText = hundredthRound(
             lineAverage
           )
             .toString()


### PR DESCRIPTION
Mon école met des pastilles de compétences à côté des notes, et elles étaient comptées comme des notes par l'addon, j'ai ajouté un if pour que seules les objets avec une valeur type "19" soient comptés.

 **Résolu en 5.0.2 :**
_il y avait des problèmes avec les indices, ça utilisait les mauvaises cases (genre la case de la matière au lieu de la case des notes) pour Firefox_