### PR TITLE
Improved the style of the avg table : added background color for an group of subjects and better colors for the table

### DIFF
--- a/chrome/styles/notesTable.css
+++ b/chrome/styles/notesTable.css
@@ -36,7 +36,23 @@ table.newTable.hidden {
   display: none;
 }
 
-#encart-notes table .moyenneclasse {
+table:not(.newTable) tr.groupematiere td {
+  background-color: hsl(var(--colorbase), 78%, 95%) !important;
+}
+
+table:not(.newTable) tr td.moyennegenerale-valeur,
+table:not(.newTable) tr td span.moyennegeneralelibelle {
+  color: var(--primary-color) !important;
+}
+
+#encart-moyennes:has(table:not(.newTable)) {
+  border-collapse: collapse !important;
+  border-radius: var(--table-radius) !important;
+  border-style: hidden !important;
+  box-shadow: rgb(100 100 111 / 30%) 3px 3px 20px 0px !important;
+}
+
+#encart-notes table:not(.newTable) .moyenneclasse {
   width: 95px;
 }
 

--- a/firefox/styles/notesTable.css
+++ b/firefox/styles/notesTable.css
@@ -32,6 +32,30 @@ table.newTable td.moyennegeneralelibelle {
   border-left: 2px solid #e2e1e1;
 }
 
+table.newTable.hidden {
+  display: none;
+}
+
+table:not(.newTable) tr.groupematiere td {
+  background-color: hsl(var(--colorbase), 78%, 95%) !important;
+}
+
+table:not(.newTable) tr td.moyennegenerale-valeur,
+table:not(.newTable) tr td span.moyennegeneralelibelle {
+  color: var(--primary-color) !important;
+}
+
+#encart-moyennes:has(table:not(.newTable)) {
+  border-collapse: collapse !important;
+  border-radius: var(--table-radius) !important;
+  border-style: hidden !important;
+  box-shadow: rgb(100 100 111 / 30%) 3px 3px 20px 0px !important;
+}
+
+#encart-notes table:not(.newTable) .moyenneclasse {
+  width: 95px;
+}
+
 /* ▄▀█ █ █ █▀▀ █▀█ ▄▀█ █▀▀ █▀▀ */
 /* █▀█ ▀▄▀ ██▄ █▀▄ █▀█ █▄█ ██▄ */
 


### PR DESCRIPTION
J'ai modifié le style du tableau de moyenne pour qu'il corresponde au tableau de notes normal, j'ai rajouté une couleur plus claire pour les groupes d'enseignements.

Avant :
![image](https://github.com/user-attachments/assets/fb83a6b2-9d3a-4de7-8ab8-4aa0d93e0b93)

Après : 
![image](https://github.com/user-attachments/assets/ed381d59-d68d-4e45-9dc0-e8f8afbbbb31)
