### PR TITLE
feat(notes): réglages d'activation notes custom / matières custom / modification de note

### DIFF
--- a/src/modules/noteTableModule.js
+++ b/src/modules/noteTableModule.js
@@ -330,6 +330,13 @@ var noteTableModule = {
     const p = this._params;
     const cdIncludeCustomData = localStorage.getItem("cd-include-custom-data") !== "false";
 
+    /* ── Feature flags (réglages "notesTable") ──
+       Si une option est désactivée, la fonctionnalité ne doit ni s'afficher ni agir sur les moyennes.
+       customSubjects dépend de customNotes : il est inactif si customNotes l'est. */
+    const customNotesOn = p["customNotesFeature"] !== false;
+    const customSubjectsOn = customNotesOn && p["customSubjectsFeature"] !== false;
+    const editNotesOn = p["editNotesFeature"] !== false;
+
     function refreshNotes() {
       tableParent.dataset.averageCalculator = "";
       try {
@@ -461,38 +468,42 @@ var noteTableModule = {
     const cdWrapper = document.createElement("div");
     cdWrapper.className = "cd-global-clear-wrapper";
 
-    const cdSwitchLabel = document.createElement("label");
-    cdSwitchLabel.className = "cd-custom-data-switch-label";
-    cdSwitchLabel.title = "Prendre en compte les notes custom, modifications et matières custom dans le recalcul de la moyenne";
-    const cdSwitchChk = document.createElement("input");
-    cdSwitchChk.type = "checkbox";
-    cdSwitchChk.checked = cdIncludeCustomData;
-    cdSwitchChk.addEventListener("change", (e) => {
-      e.stopPropagation();
-      localStorage.setItem("cd-include-custom-data", cdSwitchChk.checked ? "true" : "false");
-      refreshNotes();
-    });
-    const cdSwitchTrack = document.createElement("span");
-    cdSwitchTrack.className = "cd-custom-data-switch-track";
-    const cdSwitchText = document.createElement("span");
-    cdSwitchText.textContent = "Prendre en compte les données custom";
-    cdSwitchLabel.appendChild(cdSwitchChk);
-    cdSwitchLabel.appendChild(cdSwitchTrack);
-    cdSwitchLabel.appendChild(cdSwitchText);
-    cdWrapper.appendChild(cdSwitchLabel);
+    if (customNotesOn || editNotesOn) {
+      const cdSwitchLabel = document.createElement("label");
+      cdSwitchLabel.className = "cd-custom-data-switch-label";
+      cdSwitchLabel.title = "Prendre en compte les notes custom, modifications et matières custom dans le recalcul de la moyenne";
+      const cdSwitchChk = document.createElement("input");
+      cdSwitchChk.type = "checkbox";
+      cdSwitchChk.checked = cdIncludeCustomData;
+      cdSwitchChk.addEventListener("change", (e) => {
+        e.stopPropagation();
+        localStorage.setItem("cd-include-custom-data", cdSwitchChk.checked ? "true" : "false");
+        refreshNotes();
+      });
+      const cdSwitchTrack = document.createElement("span");
+      cdSwitchTrack.className = "cd-custom-data-switch-track";
+      const cdSwitchText = document.createElement("span");
+      cdSwitchText.textContent = "Prendre en compte les données custom";
+      cdSwitchLabel.appendChild(cdSwitchChk);
+      cdSwitchLabel.appendChild(cdSwitchTrack);
+      cdSwitchLabel.appendChild(cdSwitchText);
+      cdWrapper.appendChild(cdSwitchLabel);
+    }
 
-    const cdCustomSubjectsList = getCustomSubjects();
+    const cdCustomSubjectsList = customSubjectsOn ? getCustomSubjects() : [];
 
-    const cdAddSubjectBtn = document.createElement("button");
-    cdAddSubjectBtn.type = "button";
-    cdAddSubjectBtn.className = "cd-add-subject-btn";
-    cdAddSubjectBtn.innerHTML = '<svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="pointer-events:none"><line x1="5" y1="1" x2="5" y2="9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><line x1="1" y1="5" x2="9" y2="5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg> Nouvelle matière custom';
-    cdAddSubjectBtn.addEventListener("click", () => {
-      openAddSubjectModal(refreshNotes);
-    });
-    cdWrapper.appendChild(cdAddSubjectBtn);
+    if (customSubjectsOn) {
+      const cdAddSubjectBtn = document.createElement("button");
+      cdAddSubjectBtn.type = "button";
+      cdAddSubjectBtn.className = "cd-add-subject-btn";
+      cdAddSubjectBtn.innerHTML = '<svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="pointer-events:none"><line x1="5" y1="1" x2="5" y2="9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><line x1="1" y1="5" x2="9" y2="5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg> Nouvelle matière custom';
+      cdAddSubjectBtn.addEventListener("click", () => {
+        openAddSubjectModal(refreshNotes);
+      });
+      cdWrapper.appendChild(cdAddSubjectBtn);
+    }
 
-    const cdAllKeys = Object.keys(localStorage).filter((k) => k.startsWith("customNotes_"));
+    const cdAllKeys = customNotesOn ? Object.keys(localStorage).filter((k) => k.startsWith("customNotes_")) : [];
     const cdTotalCount = cdAllKeys.reduce((sum, k) => {
       try {
         return sum + JSON.parse(localStorage.getItem(k) || "[]").length;
@@ -521,7 +532,7 @@ var noteTableModule = {
       cdWrapper.appendChild(cdGlobalClearBtn);
     }
 
-    const cdModAllKeys = Object.keys(localStorage).filter((k) => k.startsWith("modifiedNotes_"));
+    const cdModAllKeys = editNotesOn ? Object.keys(localStorage).filter((k) => k.startsWith("modifiedNotes_")) : [];
     const cdTotalMods = cdModAllKeys.reduce((sum, k) => {
       try {
         return sum + Object.keys(JSON.parse(localStorage.getItem(k) || "{}")).length;
@@ -647,6 +658,7 @@ var noteTableModule = {
             else wrapper.remove();
           });
 
+          if (editNotesOn) {
           const cdMods = getModifiedNotes(cdSubjectName);
           [...cdNotesCell.querySelectorAll("button")].forEach((btn, cdEdIdx) => {
             const valeurSpan = btn.querySelector(":scope > span.valeur");
@@ -773,7 +785,9 @@ var noteTableModule = {
               edWrapper.appendChild(resetBtn);
             }
           });
+          }
 
+          if (customNotesOn) {
           getCustomNotes(cdSubjectName).forEach((cn, cdIndex) => {
             const wrapper = document.createElement("span");
             wrapper.className = "cd-custom-note-wrapper";
@@ -837,9 +851,10 @@ var noteTableModule = {
             });
             cdNotesCell.appendChild(clearBtn);
           }
+          }
 
-          const hasCustom = cdIncludeCustomData && getCustomNotes(cdSubjectName).length > 0;
-          const hasMods = cdIncludeCustomData && Object.keys(getModifiedNotes(cdSubjectName)).length > 0;
+          const hasCustom = cdIncludeCustomData && customNotesOn && getCustomNotes(cdSubjectName).length > 0;
+          const hasMods = cdIncludeCustomData && editNotesOn && Object.keys(getModifiedNotes(cdSubjectName)).length > 0;
           line.dataset.cdHasCustomNotes = hasCustom || hasMods ? "1" : "";
         }
       }

--- a/src/scripts/parameters.js
+++ b/src/scripts/parameters.js
@@ -53,6 +53,9 @@ new RowSelector(
   ],
   false
 );
+new Switch(notesTable, "customNotesFeature", "file-bookmark", "Notes custom", "Ajouter des notes prédictives et gérer l'ensemble du système autour", true, true);
+new Switch(notesTable, "customSubjectsFeature", "shapes", "Matières custom", "Ajouter une matière et gérer l'ensemble du système autour", true, true, false, "customNotesFeature");
+new Switch(notesTable, "editNotesFeature", "draw-square", "Modifier une note", "Modifier une note déjà présente sur EcoleDirecte", true, true);
 
 const sidebar = new Group("sidebar", "sidebar", "Barre latérale", "Paramètres de la barre latérale", false);
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -602,6 +602,13 @@ class Group extends Identity {
           }
         }
       });
+
+      // Réapplique les dépendances entre paramètres (option "requires")
+      Group.groups.forEach((group) => {
+        for (const parameter of group.parameters) {
+          if (parameter.requires) parameter.applyDependencyState();
+        }
+      });
     });
   }
 }
@@ -646,8 +653,9 @@ class Parameter extends Identity {
    * @param {*} defaultValue - La valeur par défaut du paramètre.
    * @param {boolean} reloadingRequired - Indique si un rechargement est nécessaire après la modification du paramètre.
    * @param {string|boolean} warning - Un avertissement à afficher si nécessaire.
+   * @param {string|boolean} requires - Identifiant d'un autre paramètre du même groupe qui doit être activé pour que celui-ci le soit.
    */
-  constructor(group, id, icon, name, description, type, defaultValue, reloadingRequired = false, warning = false) {
+  constructor(group, id, icon, name, description, type, defaultValue, reloadingRequired = false, warning = false, requires = false) {
     super(id, icon, name, description);
     this.group = group;
     group.addParameter(this);
@@ -655,6 +663,33 @@ class Parameter extends Identity {
     this.reloadingRequired = reloadingRequired;
     this.warning = warning;
     this.defaultValue = defaultValue;
+    this.requires = requires;
+  }
+
+  /**
+   * Applique l'état de dépendance d'un paramètre lié à un autre (option "requires").
+   * Si le paramètre parent est désactivé, ce paramètre est forcé à false et verrouillé dans l'UI.
+   */
+  applyDependencyState() {
+    if (!this.requires) return;
+    const parent = this.group.parameters.find((parameter) => parameter.id === this.requires);
+    if (!parent) return;
+    const parentOn = parent.value != false;
+
+    // Force la valeur à false tant que le parent est désactivé
+    if (!parentOn && this.value != false) {
+      this.value = false;
+      this.exportValue(false);
+    }
+
+    // Verrouille / déverrouille l'UI (uniquement dans le popup)
+    if (this.htmlElement) {
+      const input = this.htmlElement.querySelector("#switch");
+      if (input) input.disabled = !parentOn;
+      this.htmlElement.style.opacity = parentOn ? "" : "0.5";
+      this.htmlElement.style.pointerEvents = parentOn ? "" : "none";
+      this.htmlElement.setAttribute("data-locked", parentOn ? "false" : "true");
+    }
   }
 
   /**
@@ -759,6 +794,9 @@ class Parameter extends Identity {
       <div style="font-size: 16px;"> ${description} </div>
       `);
     tippy(this.htmlElement.querySelector("#description"), { placement: "left", allowHTML: true, content: descriptionTooltip, appendTo: () => document.querySelector(".tippyParent") });
+
+    // Verrouille le paramètre si sa dépendance n'est pas satisfaite
+    if (this.requires) this.applyDependencyState();
   }
 }
 
@@ -768,8 +806,8 @@ class Parameter extends Identity {
  * @description Un interrupteur permet d'activer ou de désactiver une fonctionnalité.
  */
 class Switch extends Parameter {
-  constructor(group, id, icon, name, description, defaultValue = true, reloadingRequired = false, warning = false) {
-    super(group, id, icon, name, description, "switch", defaultValue, reloadingRequired, warning);
+  constructor(group, id, icon, name, description, defaultValue = true, reloadingRequired = false, warning = false, requires = false) {
+    super(group, id, icon, name, description, "switch", defaultValue, reloadingRequired, warning, requires);
   }
 
   importValue(defaultValue) {


### PR DESCRIPTION
## Contexte

Les options permettant d'activer/désactiver les fonctionnalités de prédiction de notes existaient en V2 mais ont été retirées lors de la refonte des réglages en V3. Cette PR les réintroduit dans le moteur de réglages V3.

## Changements

### `scripts/parameters.js`
Ajout de 3 `Switch` dans le groupe **Notes** (`notesTable`), tous activés par défaut et `reloadingRequired: true` :

| Réglage | id | Dépendance |
|---|---|---|
| Notes custom | `customNotesFeature` | — |
| Matières custom | `customSubjectsFeature` | requiert `customNotesFeature` |
| Modifier une note | `editNotesFeature` | — |

### `scripts/settings.js`
Ajout d'un mécanisme de dépendance `requires` entre paramètres (nouvel argument optionnel sur `Parameter`/`Switch`). Si le paramètre parent est désactivé, l'enfant est forcé à `false` et verrouillé/grisé dans le popup. La dépendance est réévaluée au rendu initial et à chaque changement de réglage.

→ « Matières custom » ne peut s'activer que si « Notes custom » est activé.

### `modules/noteTableModule.js`
L'UI et le recalcul des moyennes sont conditionnés à ces options. Désactivée, une fonctionnalité **disparaît de l'interface** et **n'agit plus sur les moyennes** :
- **Notes custom** off → plus de bouton d'ajout, de notes custom affichées ni de suppression globale ; exclues du recalcul.
- **Matières custom** off → plus de bouton « Nouvelle matière custom » ni de lignes de matières custom.
- **Modifier une note** off → plus de bouton crayon/réinitialiser, modifications non appliquées, bouton « Rétablir toutes les notes modifiées » caché.
- Le switch « Prendre en compte les données custom » n'apparaît que si au moins une de ces fonctionnalités est active.

## Tests
- `node --check` OK sur les 3 fichiers.
- Aucune régénération Tailwind nécessaire (réutilisation du `Switch` existant ; verrouillage en styles inline).
- À vérifier en navigateur : apparition des toggles, verrouillage auto de « Matières custom », disparition de l'UI et exclusion du recalcul après désactivation + rechargement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)